### PR TITLE
Fix middleware issue when using multiple params in route

### DIFF
--- a/src/Blueprint.Api.Http/MessagePopulation/HttpRouteMessagePopulationSource.cs
+++ b/src/Blueprint.Api.Http/MessagePopulation/HttpRouteMessagePopulationSource.cs
@@ -72,6 +72,10 @@ namespace Blueprint.Api.Http.MessagePopulation
             var operationVariable = context.VariableFromContext(context.Descriptor.OperationType);
             var operationContextVariable = context.VariableFromContext(typeof(ApiOperationContext));
 
+            // Add a single setter frame so we only grab using GetRouteData() once
+            var routeDataFrame = new MethodCall(typeof(ApiOperationContextHttpExtensions), nameof(ApiOperationContextHttpExtensions.GetRouteData));
+            context.ExecuteMethod.Frames.Add(routeDataFrame);
+
             foreach (var routePropertyPlaceholder in placeholderProperties)
             {
                 var routeProperty = routePropertyPlaceholder.Property;
@@ -84,11 +88,8 @@ namespace Blueprint.Api.Http.MessagePopulation
                 }
 
                 var operationProperty = operationVariable.GetProperty(routeProperty.Name);
-                var routeDataFrame = new MethodCall(typeof(ApiOperationContextHttpExtensions), nameof(ApiOperationContextHttpExtensions.GetRouteData));
                 var routeValuesVariable = routeDataFrame.ReturnVariable.GetProperty(nameof(RouteData.Values));
 
-                // Add a single setter frame so we only grab using GetRouteData() once
-                context.ExecuteMethod.Frames.Add(routeDataFrame);
 
                 // If the property exists in ALL routes for the operation then we know it _must_ exist in RouteData otherwise we would
                 // not have got this far as the URL would not have matched. Therefore we do not need the TryGetValue method call and instead can

--- a/tests/Blueprint.Tests/Api/ResourceEvent_Middleware/Given_Multiple_Parameters_In_Route.cs
+++ b/tests/Blueprint.Tests/Api/ResourceEvent_Middleware/Given_Multiple_Parameters_In_Route.cs
@@ -1,0 +1,82 @@
+namespace Blueprint.Tests.Api.ResourceEvent_Middleware
+{
+    using System.ComponentModel.DataAnnotations;
+    using System.Threading.Tasks;
+    using Blueprint.Api;
+    using Blueprint.Api.Configuration;
+    using FluentAssertions;
+    using NUnit.Framework;
+    using Testing;
+
+    public class Given_Multiple_Parameters_In_Route
+    {
+        public class CreationOperation : ICommand
+        {
+            [Required]
+            public string IdToCreate { get; set; }
+
+            public string EmailToCreate { get; set; }
+
+            public CreatedResourceEvent Invoke()
+            {
+                return new CreatedResourceEvent(new SelfQuery { Id = IdToCreate, Email = EmailToCreate});
+            }
+        }
+
+        // Pick any authorisation that we would not have
+        [SelfLink(typeof(AwesomeApiResource), "/resources/{Id}/path/{Email}")]
+        public class SelfQuery : IQuery<AwesomeApiResource>
+        {
+            [Required]
+            public string Id { get; set; }
+
+            [Required]
+            public string Email { get; set; }
+
+            public AwesomeApiResource Invoke()
+            {
+                return new AwesomeApiResource
+                {
+                    Id = Id,
+                    Email = Email
+                };
+            }
+        }
+
+        public class CreatedResourceEvent : ResourceCreated<AwesomeApiResource>
+        {
+            public CreatedResourceEvent(IApiOperation<AwesomeApiResource> selfQuery) : base(selfQuery)
+            {
+            }
+        }
+
+        public class AwesomeApiResource : ApiResource
+        {
+            public string Id { get; set; }
+
+            public string Email { get; set; }
+        }
+
+        [Test]
+        public async Task When_HttpMessagePopulation_Operation_Then_Properties_Are_Populated()
+        {
+            // Arrange
+            var executor = TestApiOperationExecutor.Create(o => o
+                .WithOperation<CreationOperation>()
+                .WithOperation<SelfQuery>()
+                .Configure(a => a.AddHttp())
+                .Pipeline(p => p.AddResourceEvents<NullResourceEventRepository>()));
+
+            // Act
+            var context = executor.HttpContextFor<CreationOperation>();
+            ((CreationOperation)context.Operation).IdToCreate = "1234";
+            ((CreationOperation)context.Operation).EmailToCreate = "test@email.com";
+
+            var result = await executor.ExecuteAsync(context);
+
+            // Assert
+            result.ShouldBeContent<CreatedResourceEvent>().Data.Id.Should().Be("1234");
+            result.ShouldBeContent<CreatedResourceEvent>().Data.Email.Should().Be("test@email.com");
+        }
+    }
+}


### PR DESCRIPTION
The HttpRouteMessagePopulationSource generates a variable for routeData every time it goes round the loop.

(screenshot from older version but exists in current)
![image](https://user-images.githubusercontent.com/1906419/78459874-21b62f00-76b4-11ea-8e24-43ec32bf0c98.png)

- Moved the variable to outside of the loop.
- Added test to verify