### PR TITLE
[compiler] Fix missing unwrapping of ValueTask in MethodCall

### DIFF
--- a/src/Blueprint.Compiler/Frames/MethodCall.cs
+++ b/src/Blueprint.Compiler/Frames/MethodCall.cs
@@ -218,12 +218,12 @@ namespace Blueprint.Compiler.Frames
 
         private static Type CorrectedReturnType(Type type)
         {
-            if (type == typeof(Task) || type == typeof(void))
+            if (type == typeof(Task) || type == typeof(ValueTask) || type == typeof(void))
             {
                 return null;
             }
 
-            if (type.CanBeCastTo<Task>())
+            if (type.CanBeCastTo<Task>() || type.CanBeCastTo<ValueTask>())
             {
                 return type.GetGenericArguments().First();
             }

--- a/src/Blueprint.Compiler/Frames/MethodCall.cs
+++ b/src/Blueprint.Compiler/Frames/MethodCall.cs
@@ -223,7 +223,13 @@ namespace Blueprint.Compiler.Frames
                 return null;
             }
 
-            if (type.CanBeCastTo<Task>() || type.CanBeCastTo<ValueTask>())
+            if (type.CanBeCastTo<Task>())
+            {
+                return type.GetGenericArguments().First();
+            }
+
+            // have to do a manual check for ValueTask<T> as it doesn't inherit from ValueTask
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ValueTask<>))
             {
                 return type.GetGenericArguments().First();
             }

--- a/tests/Blueprint.Compiler.Tests/Codegen/MethodCallTester.cs
+++ b/tests/Blueprint.Compiler.Tests/Codegen/MethodCallTester.cs
@@ -50,6 +50,17 @@ namespace Blueprint.Compiler.Tests.Codegen
         }
 
         [Test]
+        public void determine_return_value_of_ValueTask_of_T_simple()
+        {
+            var @call = MethodCall.For<MethodCallTarget>(x => x.GetStringValue());
+            @call.ReturnVariable.Should().NotBeNull();
+
+            @call.ReturnVariable.VariableType.Should().Be(typeof(string));
+            @call.ReturnVariable.Usage.Should().Be("result_of_GetStringValue");
+            @call.ReturnVariable.Creator.Should().BeSameAs(@call);
+        }
+
+        [Test]
         public void determine_return_value_of_not_simple_type_in_a_task()
         {
             var @call = MethodCall.For<MethodCallTarget>(x => x.GetAsyncError());
@@ -188,6 +199,11 @@ namespace Blueprint.Compiler.Tests.Codegen
         public Task<string> GetString()
         {
             return Task.FromResult("foo");
+        }
+
+        public ValueTask<string> GetStringValue()
+        {
+            return new ValueTask<string>("foo");
         }
     }
 


### PR DESCRIPTION
Operations that return a ValueTask are not being unwrapped by blueprint compiler and therefore generate incorrect outputs when the return type inherits from OperationResult